### PR TITLE
Add missing return statements back

### DIFF
--- a/src/routes/info.js
+++ b/src/routes/info.js
@@ -17,7 +17,7 @@ module.exports = {
     let token = req.query.token;
     if(!token) {
       console.log("No token provided");
-      reply.view('error', {
+      return reply.view('error', {
         error : loginError
       });
     }
@@ -30,7 +30,7 @@ module.exports = {
       userTable.insert(user, function (err, data) {
         if (err) {
           console.log("Error adding user: ", err);
-          reply.view('error', {
+          return reply.view('error', {
             error : databaseError
           });
         }

--- a/src/routes/submit.js
+++ b/src/routes/submit.js
@@ -21,7 +21,7 @@ module.exports = {
       let token = req.auth.credentials.auth;
       if(!token) {
         console.log("No token provided");
-        reply.view('error', {
+        return reply.view('error', {
           error : yotiError
         });
       }
@@ -32,7 +32,7 @@ module.exports = {
         requestTable.insert(request, (err) => {
           if(err) {
             console.log("Form data error: ", err);
-            reply.view('error', {
+            return reply.view('error', {
               error : databaseError
             });
           }


### PR DESCRIPTION
I think I went a bit too far with the refactoring ;)

If there are no return statements, then the function won't exit upon an error but will keep going (e.g. if there is no token, it will still try to decode it).
